### PR TITLE
Add stepback when pressing the '4' key.

### DIFF
--- a/KODI Remote.wdgt/main.js
+++ b/KODI Remote.wdgt/main.js
@@ -240,6 +240,9 @@ function KeyCheck(event) {
             case 13:
                 Remote('Input.Select'); // Select (Enter)
                 break;
+            case 52:
+                Remote('Input.ExecuteAction','stepback'); // Left (4)
+                break;
             case 37:
                 ShiftFunc('stepback','Input.Left'); // Left
                 break;


### PR DESCRIPTION
I wanted a way to do this quickly and hitting the Dashboard button and
_then_ shift-arrow (1) takes too long, and (2) requires two hands or
reaching across the keyboard with one.  Reading back it seems like the
arrow keys have two actions, the (big) step forward/back thing and
navigating menus.  I don't know how the phone/tablet remote apps deal
with this but they seem to do it transparently so this seems like the
next best thing, since I very often want to rewind a little bit because
I missed a line of dialog or something.
